### PR TITLE
Magic v3

### DIFF
--- a/src/map/battle.cpp
+++ b/src/map/battle.cpp
@@ -134,7 +134,9 @@ int battle_get_range(dumb_ptr<block_list> bl)
     if (bl->bl_type == BL::MOB)
         return get_mob_db(bl->is_mob()->mob_class).range;
     else if (bl->bl_type == BL::PC)
-        return bl->is_player()->attackrange;
+        return (bl->is_player()->attack_spell_override
+                    ? bl->is_player()->attack_spell_range
+                    : bl->is_player()->attackrange);
     else
         return 0;
 }


### PR DESCRIPTION
Fixes issue with range in spells.

It starts void pc_set_attack_info(dumb_ptr<map_session_data> sd, interval_t speed, int range) in pc.cpp.

Looks like sd->attackrange was only overridden in magic itself and not directly written to the sd. Makes sense when you think about how old magic worked.

I see its so magic can dodge the AC_OWL and some other things that would give it an absurd bonus. (up to 31%)
